### PR TITLE
增加适性继承提示，增加AI通信标记

### DIFF
--- a/UmamusumeResponseAnalyzer/AI/GameStatusSend_Legend.cs
+++ b/UmamusumeResponseAnalyzer/AI/GameStatusSend_Legend.cs
@@ -29,6 +29,8 @@ namespace UmamusumeResponseAnalyzer.AI
     public class GameStatusSend_Legend
     {
         public bool islegal;//是否为有效的回合数据
+        public int scenarioId;  // 剧本编号
+        public string protocolVersion; // 通信数据版本
 
         public int umaId;//马娘编号，见KnownUmas.cpp
         public int umaStar;//几星
@@ -104,6 +106,9 @@ namespace UmamusumeResponseAnalyzer.AI
         public GameStatusSend_Legend(Gallop.SingleModeCheckEventResponse @event)
         {
             islegal = true;
+            scenarioId = 10;
+            protocolVersion = "250405";
+
             stage = Handlers.GetCommandInfoStage_legend(@event);
             if (stage == 0)
             {


### PR DESCRIPTION
AI通信增加两个字段 int scenarioId和 string protocolVersion
目前只在Legend杯增加了这个数据
AI处理时应先判断这两个字段存在，并且scenarioId = 10， protocolVersion等于AI记录的版本，以避免后续解析出现错误